### PR TITLE
Change status bar message

### DIFF
--- a/src/CommandHandler.cs
+++ b/src/CommandHandler.cs
@@ -48,7 +48,7 @@ namespace ShowSelectionLength
 
                 if (length > 0)
                 {
-                    await VS.StatusBar.ShowMessageAsync($"Selection {length}C {linesCount}L");
+                    await VS.StatusBar.ShowMessageAsync($"Selection Ln: {linesCount} Ch: {length}");
                 }
 
             }).FireAndForget();


### PR DESCRIPTION
Change status bar message to Ch: {count} for characters count instead of C and Ln: {count} for lines count instead of L to match what show Visual Studio for current selector position.